### PR TITLE
Fix remove method not supported in IE 11

### DIFF
--- a/components/handsontable/handsontable.ts
+++ b/components/handsontable/handsontable.ts
@@ -102,8 +102,8 @@ export class HotTable implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy() {
-    if (this.view) {
-      this.view.remove();
+    if (this.view && this.view.parentElement) {
+      this.view.parentElement.removeChild(this.view);
     }
     if (this.pagedDataSubscription) {
       this.pagedDataSubscription.unsubscribe();


### PR DESCRIPTION
Hello!

We've experienced some problems when using IE 11. Since the `remove` method is [not supported](http://caniuse.com/#search=remove) for this version of IE, we've added a workaround where the `removeChild` method on the `parentElement` of view is being used instead of the not yet supported method `remove`.