### PR TITLE
Update handsontable to ^0.31.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@angular/forms": "^2.4.0",
     "@angular/platform-browser": "^2.4.0",
     "@angular/platform-browser-dynamic": "^2.4.0",
-    "handsontable": "^0.30.0",
+    "handsontable": "^0.31.1",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "0.6.25"
   },


### PR DESCRIPTION
The only one breaking change in Handsontable [0.31](https://github.com/handsontable/handsontable/releases/tag/0.31.0) is not breaking for the Angular integration, so we can just update the version in the dependencies to that, or even to the latest version, which is a patch release to that, containing the fix for the [multiple event firing bug](https://github.com/handsontable/handsontable/issues/3343), which I needed for a project I'm working on.