### PR TITLE
Fix typo in afterPaste output

### DIFF
--- a/src/handsontable.component.ts
+++ b/src/handsontable.component.ts
@@ -49,7 +49,7 @@ export class HotTableComponent implements OnInit, OnDestroy, OnChanges {
   @Output() public afterDropdownMenuDefaultOptions = new EventEmitter();
   @Output() public afterDropdownMenuHide = new EventEmitter();
   @Output() public afterDropdownMenuShow = new EventEmitter();
-  @Output() public afterePaste = new EventEmitter();
+  @Output() public afterPaste = new EventEmitter();
   @Output() public afterFilter = new EventEmitter();
   @Output() public afterGetCellMeta = new EventEmitter();
   @Output() public afterGetColHeader = new EventEmitter();


### PR DESCRIPTION
A typo in the afterPaste hook has been fixed in a recent release of Handsontable (afterePaste -> afterPaste)

I cannot find when this fix has been released but their doc has been updated with [this pull request](https://github.com/handsontable/handsontable/pull/4544)

Thanks